### PR TITLE
time to read component

### DIFF
--- a/components/doc-metadata/DocMetadata.tsx
+++ b/components/doc-metadata/DocMetadata.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useConfig } from "nextra-theme-docs";
+import { TimeToRead } from "./TimeToRead";
+
+export function DocMetadata() {
+    const metadata = useConfig().normalizePagesResult.activeMetadata;
+
+    return <>
+        <TimeToRead metadata={metadata} />
+    </>
+}

--- a/components/doc-metadata/TimeToRead.tsx
+++ b/components/doc-metadata/TimeToRead.tsx
@@ -1,0 +1,27 @@
+import { LucideClock } from "lucide-react";
+import { FrontMatter } from "nextra";
+
+// conditionally polyfill Temporal for Safari :(
+const loadTemporal = async () => {
+    if (typeof Temporal === 'undefined') {
+        const polyfill = await import('@js-temporal/polyfill');
+        window.Temporal = polyfill.Temporal;
+    }
+};
+
+await loadTemporal();
+
+export function TimeToRead({ metadata }: { metadata?: FrontMatter }) {
+    if (metadata?.readingTime == null) return null;
+
+    return (<dl className="flex w-full p-2 gap-2 border-solid border-white border-thick">
+        <dt className="">
+            <div className="flex gap-2 font-semibold">
+                <LucideClock /> Time to read
+            </div>
+        </dt>
+        <dd>
+            {Temporal.Duration.from(metadata.readingTime).toLocaleString()}
+        </dd>
+    </dl>)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "5st-docs",
       "version": "0.1.0",
       "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
         "lucide-react": "^1.25.0",
         "next": "16.2.10",
         "nextra": "^4.6.1",
@@ -1189,6 +1190,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -7149,6 +7162,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postbuild": "pagefind --site .next/server/app --output-path out/_pagefind"
   },
   "dependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "lucide-react": "^1.25.0",
     "next": "16.2.10",
     "nextra": "^4.6.1",


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description
This PR adds the `DocMetadata` wrapper component for displaying document metadata at the top of a document page.

It also adds the `TimeToRead` component, included in `DocMetadata` as the first example of a metadata component.

### Usage

1. Add `<DocMetadata />` at the top of your .mdx pages to include any metadata components
2. Add suitable metadata to your document's frontmatter, e.g.

```mdx
---
readingTime: PT15M
---

import {DocMetadata} from "@components/doc-metadata/DocMetadata"
<DocMetadata/>

# My Docs
...
```

For `readingTime` the format is ISO 8601 Duration.

