### PR TITLE
Fix deploy and check-build workflow

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -34,24 +34,6 @@ jobs:
           path: likec4_src
           output: public/images/likec4
 
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "./yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "./package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
-
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
@@ -65,24 +47,12 @@ jobs:
         with:
           path: |
             .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-        working-directory: .
+        run: npm ci
 
-      - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
-        working-directory: .
-
-      - name: Copy built files to docs
-        run: |
-          rm -rf docs/*
-          cp -r ./out docs/
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs
+      - name: Check build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the docs site.
 
-**LikeC4 Development**
+### LikeC4 Development
 
-If you encounter 404 errors on the C4 diagrams, try running the following command to generate the images:
+- If you encounter 404 errors on the C4 diagrams, try running the following command to generate the images:
 
 ```bash
 npm run likec4:export
 ```
 
-The images will be exported to the `public/images/likec4` directory.
+It will try to install `playwright` if it's not already installed before exporting the images. The images will be exported to the `public/images/likec4` directory.
 
-If you are developing the likeC4 code, you can run the following command to start the likeC4 development server (localhost:5173):
+- If you are developing the likeC4 code, you can run the following command to start the likeC4 development server (localhost:5173):
 
 ```bash
 npm run likec4:dev
@@ -28,15 +28,22 @@ npm run likec4:dev
 
 Edit the source code in the likec4_src directory and then the images will be updated automatically.
 
-NOTE: You can edit the positions/layout of the components of likeC4 diagrams using the web browser. The modifications will be saved in the `/likec4_src/.likec4` directory as `snap` files. Just keep them and export the images again to see the changes in the docs site.
+**NOTE**: You can edit the positions/layout of the components of likeC4 diagrams using the web browser. The modifications will be saved in the `/likec4_src/.likec4` directory as `snap` files. Just keep them and export the images again to see the changes in the docs site.
 
-To export the images to see them in the docs
+- To export the images to see them in the docs, run the following command:
 
 ```bash
 npm run likec4:export
 ```
 
-**Enable Search on Dev**
+- Before building the docs site locally (`npm run build`), make sure to run the following commands to generate LikeC4 React code and export the images first:
+
+```bash
+npm run likec4:codegen
+npm run likec4:export
+```
+
+### Enable Search on Dev
 
 To enable/test search functionality on development server, run the following command:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev": "next --turbopack",
     "predev": "npm run likec4:codegen",
     "build": "next build",
-    "prebuild": "npm run likec4:codegen",
     "start": "npx serve out",
     "lint": "eslint",
     "postbuild": "pagefind --site .next/server/app --output-path out/_pagefind",


### PR DESCRIPTION
# Description

This PR removed the `prebuild` command, which caused the deploy workflow to fail. Also, making two workflow to be more consistent and added more guidance to the README.


## Review checks

<!-- No author action required beyond this point -->

### Metadata

#### Frontmatter
- [ ] `<DocMetadata />` component at top of document
- [ ] `docType`
    - `journey` - A page of curated suggested documents for a persona or purpose
    - `explanation` per [Diataxis]
    - `tutorial` per [Diataxis]
    - `guide` per [Diataxis]
    - `reference` per [Diataxis]
    - Category or splash pages do not require this
- [ ] `readingTime` in [ISO 8601 Duration] format
    - Only required for `explanation`, `tutorial` and `guide`
- [ ] `audiences` - one or more target audiences for the content
    - `federation-operator`
    - `tre-operator`
    - `researcher`
    - `integrator`
    - `contributor`
    - `everyone`

#### Content

- [ ] Prerequisites, if appropriate
- [ ] Next steps, if appropriate

[diataxis]: https://diataxis.fr/
[ISO 8601 Duration]: https://en.wikipedia.org/wiki/ISO_8601#Durations