### PR TITLE
Fix the LikeC4 viewport (with manual layout) in production

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -20,22 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: LikeC4 code generation
-        uses: likec4/actions@d36a6b8c87c1d540a3737302808755db435183b0 # v1.89.0
-        with:
-          codegen: react
-          path: likec4_src
-          output: likec4_react/likec4.generated.js
-          likec4-version: 1.59.2
-
-      - name: LikeC4 PNG export
-        uses: likec4/actions@d36a6b8c87c1d540a3737302808755db435183b0 # v1.89.0
-        with:
-          export: png
-          path: likec4_src
-          output: public/images/likec4
-          likec4-version: 1.59.2
-
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
@@ -55,6 +39,18 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # LikeC4 runs from the repo's own dependency rather than likec4/actions,
+      # whose image pins Playwright 1.56.1 browsers and cannot run likec4 1.58+.
+      # This supports manual layout snapshots rendering the same in CI as they do locally.
+      - name: LikeC4 code generation
+        run: npm run likec4:codegen
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: LikeC4 PNG export
+        run: npx likec4 export png likec4_src -o public/images/likec4
 
       - name: Check build
         run: npm run build

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -26,6 +26,7 @@ jobs:
           codegen: react
           path: likec4_src
           output: likec4_react/likec4.generated.js
+          likec4-version: 1.59.2
 
       - name: LikeC4 PNG export
         uses: likec4/actions@d36a6b8c87c1d540a3737302808755db435183b0 # v1.89.0
@@ -33,6 +34,7 @@ jobs:
           export: png
           path: likec4_src
           output: public/images/likec4
+          likec4-version: 1.59.2
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
           codegen: react
           path: likec4_src
           output: likec4_react/likec4.generated.js
+          likec4-version: 1.59.2
 
       - name: LikeC4 PNG export
         uses: likec4/actions@d36a6b8c87c1d540a3737302808755db435183b0 # v1.89.0
@@ -36,6 +37,7 @@ jobs:
           export: png
           path: likec4_src
           output: public/images/likec4
+          likec4-version: 1.59.2
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,22 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: LikeC4 code generation
-        uses: likec4/actions@d36a6b8c87c1d540a3737302808755db435183b0 # v1.89.0
-        with:
-          codegen: react
-          path: likec4_src
-          output: likec4_react/likec4.generated.js
-          likec4-version: 1.59.2
-
-      - name: LikeC4 PNG export
-        uses: likec4/actions@d36a6b8c87c1d540a3737302808755db435183b0 # v1.89.0
-        with:
-          export: png
-          path: likec4_src
-          output: public/images/likec4
-          likec4-version: 1.59.2
-
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
@@ -59,6 +43,18 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # LikeC4 runs from the repo's own dependency rather than likec4/actions,
+      # whose image pins Playwright 1.56.1 browsers and cannot run likec4 1.58+.
+      # This supports manual layout snapshots rendering the same in CI as they do locally.
+      - name: LikeC4 code generation
+        run: npm run likec4:codegen
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: LikeC4 PNG export
+        run: npx likec4 export png likec4_src -o public/images/likec4
 
       # Must use `npm run build` (not `npx next build`) so the postbuild
       # Pagefind step runs and writes search assets into out/_pagefind.


### PR DESCRIPTION
# Description

Fix the LikeC4 viewport in production. The problem was that LikeC4 1.44.0 has a bug with the viewport (https://github.com/likec4/likec4/issues/2382), and this is fixed in 1.45. Also, from 1.45 to 1.59.2 (the latest) there are other fixes and improvements. However, the latest likeC4 GH action still uses `playwright:v1.56.1` in the base image, which won't be compatible with likeC4 1.59.2.

So the solution is to build and run from the repo's dependencies. This supports manual layout snapshots rendering the same in CI as they do locally.


## Review checks

<!-- No author action required beyond this point -->

### Metadata

#### Frontmatter
- [ ] `<DocMetadata />` component at top of document
- [ ] `docType`
    - `journey` - A page of curated suggested documents for a persona or purpose
    - `explanation` per [Diataxis]
    - `tutorial` per [Diataxis]
    - `guide` per [Diataxis]
    - `reference` per [Diataxis]
    - Category or splash pages do not require this
- [ ] `readingTime` in [ISO 8601 Duration] format
    - Only required for `explanation`, `tutorial` and `guide`
- [ ] `audiences` - one or more target audiences for the content
    - `federation-operator`
    - `tre-operator`
    - `researcher`
    - `integrator`
    - `contributor`
    - `everyone`

#### Content

- [ ] Prerequisites, if appropriate
- [ ] Next steps, if appropriate

[diataxis]: https://diataxis.fr/
[ISO 8601 Duration]: https://en.wikipedia.org/wiki/ISO_8601#Durations