### PR TITLE
Add redirect for route federated_research_patterns

### DIFF
--- a/app/_meta.js
+++ b/app/_meta.js
@@ -15,4 +15,8 @@ export default {
   five_safes_tes: {
     display: "hidden",
   },
+  // Patterns URL redirect, never show in nav
+  federated_research_patterns: {
+    display: "hidden",
+  },
 };

--- a/app/federated_research_patterns/page.tsx
+++ b/app/federated_research_patterns/page.tsx
@@ -1,0 +1,11 @@
+/* This page is here to rediect users to https://docs.federated-research.com/federated_research_patterns
+The redirect can be preserved here without conflict as this site uses kebab-case routes
+*/
+import { permanentRedirect } from 'next/navigation';
+
+export default async function WelcomeReportRedirect() {
+  // Triggers an immediate server-side HTTP 308 redirect
+  permanentRedirect('https://docs.federated-research.com/federated_research_patterns');
+
+  return null;
+}


### PR DESCRIPTION
# Description

Simon Li requested a redirection of the route `federated_research_patterns` in the new docs to the same location in the docs for Patterns and Weaves.


## Review checks

<!-- No author action required beyond this point -->

### Metadata

#### Frontmatter
- [ ] `<DocMetadata />` component at top of document
- [ ] `docType`
    - `journey` - A page of curated suggested documents for a persona or purpose
    - `explanation` per [Diataxis]
    - `tutorial` per [Diataxis]
    - `guide` per [Diataxis]
    - `reference` per [Diataxis]
    - Category or splash pages do not require this
- [ ] `readingTime` in [ISO 8601 Duration] format
    - Only required for `explanation`, `tutorial` and `guide`
- [ ] `audiences` - one or more target audiences for the content
    - `federation-operator`
    - `tre-operator`
    - `researcher`
    - `integrator`
    - `contributor`
    - `everyone`

#### Content

- [ ] Prerequisites, if appropriate
- [ ] Next steps, if appropriate

[diataxis]: https://diataxis.fr/
[ISO 8601 Duration]: https://en.wikipedia.org/wiki/ISO_8601#Durations